### PR TITLE
ci(dependabot semantic-release docker-hub): Manque la release GiitHub

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,6 +3,7 @@
   "debug": "true",
   "plugins": [
     "@semantic-release/commit-analyzer",
-    "@semantic-release/release-notes-generator"
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
fix #18